### PR TITLE
feat: 增加组件上移、下移、置顶、置底的快捷键&contextMenu菜单快捷键文字说明

### DIFF
--- a/src/components/Editor/ContextMenu.vue
+++ b/src/components/Editor/ContextMenu.vue
@@ -3,19 +3,19 @@
         <ul @mouseup="handleMouseUp">
             <template v-if="curComponent">
                 <template v-if="!curComponent.isLock">
-                    <li @click="copy">复制</li>
-                    <li @click="paste">粘贴</li>
-                    <li @click="cut">剪切</li>
-                    <li @click="deleteComponent">删除</li>
-                    <li @click="lock">锁定</li>
-                    <li @click="topComponent">置顶</li>
-                    <li @click="bottomComponent">置底</li>
-                    <li @click="upComponent">上移</li>
-                    <li @click="downComponent">下移</li>
+                    <li @click="copy">复制 ({{ shortCutKeyComment[os]['copy'] }})</li>
+                    <li @click="paste">粘贴 ({{ shortCutKeyComment[os]['paste'] }})</li>
+                    <li @click="cut">剪切 ({{ shortCutKeyComment[os]['cut'] }})</li>
+                    <li @click="deleteComponent">删除 ({{ shortCutKeyComment[os]['delete'] }})</li>
+                    <li @click="lock">锁定 ({{ shortCutKeyComment[os]['lock'] }})</li>
+                    <li @click="topComponent">置顶 ({{ shortCutKeyComment[os]['top'] }})</li>
+                    <li @click="bottomComponent">置底 ({{ shortCutKeyComment[os]['bottom'] }})</li>
+                    <li @click="upComponent">上移 ({{ shortCutKeyComment[os]['up'] }})</li>
+                    <li @click="downComponent">下移 ({{ shortCutKeyComment[os]['down'] }})</li>
                 </template>
                 <li v-else @click="unlock">解锁</li>
             </template>
-            <li v-else @click="paste">粘贴</li>
+            <li v-else @click="paste">粘贴 ({{ shortCutKeyComment[os]['paste'] }})</li>
         </ul>
     </div>
 </template>
@@ -27,6 +27,22 @@ export default {
     data() {
         return {
             copyData: null,
+            shortCutKeyComment: {
+                mac: {
+                    copy: '⌘+C',
+                    paste: '⌘+V',
+                    cut: '⌘+X',
+                    delete: '⌘+D',
+                    lock: '⌘+L',
+                    up: '⌘+⬆',
+                    down: '⌘+⬇',
+                    top: '⌘+T',
+                    bottom: '⌘+U',
+                },
+                // win shortCutKey to do
+                win: {},
+            },
+            os: '',
         }
     },
     computed: mapState([
@@ -35,6 +51,9 @@ export default {
         'menuShow',
         'curComponent',
     ]),
+    created() {
+        this.getCurOS()
+    },
     methods: {
         lock() {
             this.$store.commit('lock')
@@ -85,6 +104,12 @@ export default {
         bottomComponent() {
             this.$store.commit('bottomComponent')
             this.$store.commit('recordSnapshot')
+        },
+
+        // 获取当前操作系统
+        getCurOS() {
+            this.os = this.$store.state.os
+            console.log(this.os)
         },
     },
 }

--- a/src/store/common.js
+++ b/src/store/common.js
@@ -1,0 +1,10 @@
+export default {
+    state: {
+        os: '',
+    },
+    mutations: {
+        setCurOS(state, { os }) {
+            state.os = os
+        },
+    },
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ import event from './event'
 import layer from './layer'
 import snapshot from './snapshot'
 import lock from './lock'
+import common from './common'
 
 Vue.use(Vuex)
 
@@ -21,6 +22,7 @@ const data = {
         ...layer.state,
         ...snapshot.state,
         ...lock.state,
+        ...common.state,
 
         editMode: 'edit', // 编辑器模式 edit preview
         canvasStyleData: { // 页面全局数据
@@ -45,6 +47,7 @@ const data = {
         ...layer.mutations,
         ...snapshot.mutations,
         ...lock.mutations,
+        ...common.mutations,
 
         setClickComponentStatus(state, status) {
             state.isClickComponent = status

--- a/src/store/layer.js
+++ b/src/store/layer.js
@@ -4,6 +4,7 @@ import toast from '@/utils/toast'
 export default {
     mutations: {
         upComponent({ componentData, curComponentIndex }) {
+            // console.log()
             // 上移图层 index，表示元素在数组中越往后
             if (curComponentIndex < componentData.length - 1) {
                 swap(componentData, curComponentIndex, curComponentIndex + 1)

--- a/src/utils/shortcutKey.js
+++ b/src/utils/shortcutKey.js
@@ -20,7 +20,13 @@ const ctrlKey = 17,
     pKey = 80, // 预览
     dKey = 68, // 删除
     deleteKey = 46, // 删除
-    eKey = 69 // 清空画布
+    eKey = 69, // 清空画布
+
+    upKey = 38, // 上移
+    downKey = 40, // 下移
+
+    topKey = 84, // 置顶
+    bottomKey = 85 // 置底
 
 export const keycodes = [66, 67, 68, 69, 71, 76, 80, 83, 85, 86, 88, 89, 90]
 
@@ -50,6 +56,10 @@ const unlockMap = {
     [dKey]: deleteComponent,
     [deleteKey]: deleteComponent,
     [lKey]: lock,
+    [upKey]: up,
+    [downKey]: down,
+    [topKey]: top,
+    [bottomKey]: bottom,
 }
 
 let isCtrlOrCommandDown = false
@@ -85,6 +95,22 @@ export function listenGlobalKeyDown() {
     window.onmousedown = () => {
         store.commit('setInEditorStatus', false)
     }
+}
+
+function top() {
+    store.commit('topComponent')
+}
+
+function bottom() {
+    store.commit('bottomComponent')
+}
+
+function up() {
+    store.commit('upComponent')
+}
+
+function down() {
+    store.commit('downComponent')
 }
 
 function copy() {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -71,6 +71,7 @@ export default {
         this.restore()
         // 全局监听按键事件
         listenGlobalKeyDown()
+        this.getCurrentOS()
     },
     methods: {
         restore() {
@@ -130,6 +131,13 @@ export default {
             if (e.button != 2) {
                 this.$store.commit('hideContextMenu')
             }
+        },
+
+        // 获取当前的操作系统
+        getCurrentOS() {
+            const agent = navigator.userAgent
+            const os = agent.indexOf('Mac') ? 'mac' : 'win'
+            this.$store.commit('setCurOS', { os })
         },
     },
 }


### PR DESCRIPTION
上移:cmd + ⬆️
下移:cmd + ⬇️
置顶：cmd + t
置底：cmd + u (d已被删除占用)
效果大概如下：
<img width="551" alt="image" src="https://user-images.githubusercontent.com/36130533/181451097-77e30c46-e541-4844-9ec1-9107b385179a.png">
<img width="669" alt="image" src="https://user-images.githubusercontent.com/36130533/181451148-f3d12e06-4311-4452-bcd9-2115c215370c.png">
