### PR TITLE
perf: 解决画布存在多个图表的性能问题

### DIFF
--- a/src/custom-component/VChart/Component.vue
+++ b/src/custom-component/VChart/Component.vue
@@ -30,7 +30,9 @@ export default {
         curComponent: {
             deep: true,
             handler() {
-                this.render()
+                if (this.element.id === this.curComponent) {
+                    this.render()
+                }
             },
         },
     },


### PR DESCRIPTION
画布有多个图表时操作任意组件都会触发每个图表的render方法然后触发echarts的setOption方法造成性能问题