### PR TITLE
fix：同类型组件切换时，activeName不能正确切换。

### DIFF
--- a/src/custom-component/common/CommonAttr.vue
+++ b/src/custom-component/common/CommonAttr.vue
@@ -57,6 +57,11 @@ export default {
     created() {
         this.activeName = this.curComponent.collapseName
     },
+    watch: {
+        curComponent(){
+            this.activeName = this.curComponent.collapseName
+        }
+    },
     methods: {
         onChange() {
             this.curComponent.collapseName = this.activeName


### PR DESCRIPTION
修复同类型组件在点击切换时activeName不能响应式改变而导致属性设置面板中collapse卡片不能正确显示的问题。