### PR TITLE
fix:修复图表无法动态调整size的问题

### DIFF
--- a/src/custom-component/VChart/Component.vue
+++ b/src/custom-component/VChart/Component.vue
@@ -1,5 +1,10 @@
 <template>
-    <v-chart ref="chart" class="chart" :option="propValue.option" />
+    <v-chart 
+        ref="chart" 
+        class="chart" 
+        :option="propValue.option"
+        autoresize
+    />
 </template>
 
 <script>


### PR DESCRIPTION
加入 ”autoresize “选项字，根据根元素的宽高动态调整图表的宽高。